### PR TITLE
Remove Python/3.9.5 module load from nanopolish script

### DIFF
--- a/guppy.sh
+++ b/guppy.sh
@@ -13,5 +13,9 @@
 #SBATCH --mail-type=ALL
 #SBATCH --mail-user=bhaup057@student.otago.ac.nz
 
+
+#Instructions on running guppy-gpu on NeSI Mahuika cluster :https://support.nesi.org.nz/hc/en-gb/articles/4546820344079-ont-guppy-gpu
+module purge
 module load ont-guppy-gpu/5.0.7
+
 guppy_basecaller -i path/to/fast5/files -s ./ --flowcell FLO-MIN106 --kit SQK-LSK109 --num_callers 4 -x auto --recursive --trim_barcodes --disable_qscore_filtering

--- a/nanopolish.sh
+++ b/nanopolish.sh
@@ -13,10 +13,11 @@
 #SBATCH --mail-user=bhaup057@student.otago.ac.nz
 #SBATCH --hint=nomultithread
 
+#nanopolish will load Python/3.8.2 which is a built in dependency 
 module load nanopolish/0.13.2-gimkl-2020a
 module load SAMtools/1.12-GCC-9.2.0
 module load minimap2/2.20-GCC-9.2.0
-module load Python/3.9.5-gimkl-2020a
+
 
 nanopolish index -d /nesi/nobackup/uoo02752/nematode/nematode_nanopore/0.all_fast5/fast5.files basecalled.fastq
 minimap2 -ax map-ont -t 10 assembly.fasta basecalled.fastq | samtools sort -o basecalled.sorted.bam -T reads.tmp

--- a/nanopolish.sh
+++ b/nanopolish.sh
@@ -3,7 +3,6 @@
 #SBATCH --nodes 1
 #SBATCH --cpus-per-task 1
 #SBATCH --ntasks 30
-#SBATCH --partition=bigmem
 #SBATCH --job-name nanopolishNem
 #SBATCH --mem=10G
 #SBATCH --time=7-00:00:00

--- a/racon.5ite.sh
+++ b/racon.5ite.sh
@@ -14,8 +14,8 @@
 #SBATCH --mail-user=bhaup057@student.otago.ac.nz
 #SBATCH --hint=nomultithread
 
-module load Racon
-module load minimap2
+module load Racon/1.4.21-GCC-9.2.0-CUDA-11.2.0-hybrid
+module load minimap2/2.24-GCC-9.2.0
 
 #======> Correction 1 X Racon
 minimap2 -t 10 assembly.fasta m.neg_ont_nanolyse_porechop.fastq > m.neg.flye.gfa1.paf


### PR DESCRIPTION
nanopolish/0.13.2-gimkl-2020a has Python/3.8.2 as a built in dependency. Therefore, trying to load Python/3.9.5 might lead to conflicts. 
