### PR TITLE
Update nanopolish version and Remove python3 call 

### DIFF
--- a/nanopolish.sh
+++ b/nanopolish.sh
@@ -14,7 +14,8 @@
 #SBATCH --hint=nomultithread
 
 #nanopolish will load Python/3.8.2 which is a built in dependency 
-module load nanopolish/0.13.2-gimkl-2020a
+module purge
+module load nanopolish/0.13.3-gimkl-2020a-Python-3.9.9
 module load SAMtools/1.12-GCC-9.2.0
 module load minimap2/2.20-GCC-9.2.0
 

--- a/nanopolish.sh
+++ b/nanopolish.sh
@@ -24,5 +24,5 @@ nanopolish index -d /nesi/nobackup/uoo02752/nematode/nematode_nanopore/0.all_fas
 minimap2 -ax map-ont -t 10 assembly.fasta basecalled.fastq | samtools sort -o basecalled.sorted.bam -T reads.tmp
 samtools index basecalled.sorted.bam  
 
-python3 /scale_wlg_persistent/filesets/opt_nesi/CS400_centos7_bdw/nanopolish/0.13.2-gimkl-2020a/scripts/nanopolish_makerange.py assembly.fasta | parallel --results nanopolish.results -P 1 \
+nanopolish_makerange.py assembly.fasta | parallel --results nanopolish.results -P 1 \
 nanopolish variants --consensus -o polished.{1}.vcf -w {1} -r basecalled.fastq -b basecalled.sorted.bam -g assembly.fasta -t 30 --min-candidate-frequency 0.1


### PR DESCRIPTION
scripts directory which contains all of the nanopolish binary executables are already exported to PATH. Therefore, we can remove `python3 /path/to/scripts/nanopolish_makerange.py` and call it directly as `nanopolish_makerange.py..`